### PR TITLE
Show more information on features admin page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,3 @@ DEPENDENCIES
   green_flag!
   jquery-rails
   rspec-rails
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/stylesheets/green_flag/admin/features.css.scss
+++ b/app/assets/stylesheets/green_flag/admin/features.css.scss
@@ -16,6 +16,10 @@
   white-space: nowrap;
 }
 
+.well {
+  margin-top: 5px;
+}
+
 ul.decisions-made-summary {
   
   padding: 0;

--- a/app/controllers/green_flag/admin/features_controller.rb
+++ b/app/controllers/green_flag/admin/features_controller.rb
@@ -3,7 +3,7 @@ class GreenFlag::Admin::FeaturesController < ApplicationController
   layout 'green_flag/application'
 
   def index
-    @features = GreenFlag::Feature.all
+    @features = GreenFlag::Feature.order(:created_at).all
   end
 
   def show

--- a/app/models/green_flag/feature.rb
+++ b/app/models/green_flag/feature.rb
@@ -55,12 +55,11 @@ class GreenFlag::Feature < ActiveRecord::Base
   end
 
   def fully_enabled?
-    rules.where(:group_key => "Everyone", :percentage => 100).size > 0
+    rules.count > 0 && rules.all? { |rule| rule.percentage == 100 }
   end
 
   def fully_disabled?
-    percentages = rules.map(&:percentage)
-    percentages.size == percentages.count {|percent| percent == 0 }
+    rules.count == 0 || rules.all? { |rule| rule.percentage == 0 }
   end
   
   private

--- a/app/models/green_flag/feature.rb
+++ b/app/models/green_flag/feature.rb
@@ -53,6 +53,15 @@ class GreenFlag::Feature < ActiveRecord::Base
 
     last_rule.present? ? last_rule.version_number : version_number
   end
+
+  def fully_enabled?
+    rules.where(:group_key => "Everyone", :percentage => 100).size > 0
+  end
+
+  def fully_disabled?
+    percentages = rules.map(&:percentage)
+    percentages.size == percentages.count {|percent| percent == 0 }
+  end
   
   private
 

--- a/app/views/green_flag/admin/features/index.html.erb
+++ b/app/views/green_flag/admin/features/index.html.erb
@@ -6,8 +6,21 @@
 <div class="row">
   <% @features.each do |feature| %>
     <div class="col-md-6">
-      <h4><%= link_to feature.code, admin_feature_path(feature) %></h4>
-      <p><%= feature.description %></p>
+      <div class="well">
+        <h4>
+          <%= link_to feature.code, admin_feature_path(feature) %>
+          <% if feature.fully_enabled? %><span class="label label-success">100%</span><% end %>
+          <% if feature.fully_disabled? %><span class="label label-danger">0%</span><% end %>
+        </h4>
+        
+        <div class="help-block">
+          <div>Created at <strong><%= feature.created_at.strftime("%d %b %Y") %></strong></div>
+          <div>Enabled for <strong><%= feature.enabled_count %> people</strong></div>
+          <div>Disabled for <strong><%= feature.disabled_count %> people</strong></div>
+        </div>
+
+        <p><%= feature.description %></p>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/green_flag/admin/features/index.html.erb
+++ b/app/views/green_flag/admin/features/index.html.erb
@@ -14,9 +14,7 @@
         </h4>
         
         <div class="help-block">
-          <div>Created at <strong><%= feature.created_at.strftime("%d %b %Y") %></strong></div>
-          <div>Enabled for <strong><%= feature.enabled_count %> people</strong></div>
-          <div>Disabled for <strong><%= feature.disabled_count %> people</strong></div>
+          <div>Created on <strong><%= feature.created_at.strftime("%d %b %Y") %></strong></div>
         </div>
 
         <p><%= feature.description %></p>

--- a/spec/dummy/config/initializers/green_flag.rb
+++ b/spec/dummy/config/initializers/green_flag.rb
@@ -1,0 +1,14 @@
+GreenFlag::VisitorGroup.define do
+
+  # Basic Groups
+  group "Everyone", "This is everyone!" do
+    true
+  end
+  group "New visitors", "These are visitors who have never logged in.  (This does not include users who have signed out)" do |site_visitor|
+    !site_visitor.user
+  end
+  group "Pre-existing Visitors", "Visitors that were created before this feature was deployed.  They might have seen the old version." do |visitor, rule|
+    visitor.first_visited_at < rule.created_at
+  end
+
+end


### PR DESCRIPTION
![Image of Features](https://dl.dropboxusercontent.com/u/8556784/Screen%20Shot%202015-09-30%20at%201.26.34%20pm.png)

This will add some useful information on the features page such as:
- [x] Creation date
- [x] Is it open to a 100% of users or 0%?
- [x] Count of users its enabled/disabled for
