### PR TITLE
Adding migration for feature_decisions.feature_id index

### DIFF
--- a/db/migrate/20140818155533_add_index_to_feature_decisions.rb
+++ b/db/migrate/20140818155533_add_index_to_feature_decisions.rb
@@ -1,0 +1,7 @@
+require 'activerecord-concurrent-index'
+
+class AddIndexToFeatureDecisions < ActiveRecord::Migration
+  def change
+    add_index_concurrently :green_flag_feature_decisions, :feature_id
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(:version => 20150726204409) do
     t.integer  "rule_id"
   end
 
+  add_index "green_flag_feature_decisions", ["feature_id"], :name => "index_green_flag_feature_decisions_on_feature_id"
   add_index "green_flag_feature_decisions", ["site_visitor_id", "feature_id"], :name => "index_gf_feature_decisions_on_site_visitor_id_feature_id", :unique => true
 
   create_table "green_flag_feature_events", :force => true do |t|


### PR DESCRIPTION
I left out this migration when extracting from the original app.
