### PR TITLE
Precompile assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,6 @@ source "https://rubygems.org"
 # development dependencies will be added by default to the :development group.
 gemspec
 
-# jquery-rails is used by the dummy application
-gem "jquery-rails"
-
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/green_flag.gemspec
+++ b/green_flag.gemspec
@@ -26,7 +26,11 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 3.2"
   s.add_dependency "pg"
   s.add_dependency "activerecord-concurrent-index"
+
+  # Assets for the admin pages
+  s.add_dependency "jquery-rails"
   s.add_dependency "sass-rails"
+  s.add_dependency "uglifier"
 
   s.add_development_dependency 'rspec-rails', "~> 2"
   s.add_development_dependency 'factory_girl_rails'

--- a/lib/green_flag.rb
+++ b/lib/green_flag.rb
@@ -1,4 +1,5 @@
 require "green_flag/engine"
+require "jquery-rails"
 
 module GreenFlag
 end

--- a/lib/green_flag/engine.rb
+++ b/lib/green_flag/engine.rb
@@ -14,7 +14,13 @@ module GreenFlag
     end
 
     initializer "Asset precompilation", :group => :all do |app|
-      app.config.assets.precompile += %w(feature-deletion.js features.js rules.js)
+      app.config.assets.precompile += %w(
+        green_flag/admin/feature-deletion.js
+        green_flag/admin/features.js
+        green_flag/admin/rules.js
+        green_flag/admin/features.css
+        green_flag/admin/rules.css
+      )
     end
   end
 end

--- a/lib/green_flag/engine.rb
+++ b/lib/green_flag/engine.rb
@@ -14,7 +14,7 @@ module GreenFlag
     end
 
     initializer "Asset precompilation", :group => :all do |app|
-      app.config.assets.precompile = ['*.js', '*.css']
+      app.config.assets.precompile += %w(feature-deletion.js features.js rules.js)
     end
   end
 end

--- a/lib/green_flag/engine.rb
+++ b/lib/green_flag/engine.rb
@@ -11,6 +11,8 @@ module GreenFlag
 
     initializer "green_flag.site_visitor_management" do |app|
       ActionController::Base.send :include, GreenFlag::SiteVisitorManagement
+
+      config.assets.precompile = ['*.js', '*.css']
     end
   end
 end

--- a/lib/green_flag/engine.rb
+++ b/lib/green_flag/engine.rb
@@ -12,7 +12,7 @@ module GreenFlag
     initializer "green_flag.site_visitor_management" do |app|
       ActionController::Base.send :include, GreenFlag::SiteVisitorManagement
 
-      config.assets.precompile = ['*.js', '*.css']
+      app.config.assets.precompile = ['*.js', '*.css']
     end
   end
 end

--- a/lib/green_flag/engine.rb
+++ b/lib/green_flag/engine.rb
@@ -11,7 +11,9 @@ module GreenFlag
 
     initializer "green_flag.site_visitor_management" do |app|
       ActionController::Base.send :include, GreenFlag::SiteVisitorManagement
+    end
 
+    initializer "Asset precompilation", :group => :all do |app|
       app.config.assets.precompile = ['*.js', '*.css']
     end
   end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -41,3 +41,7 @@ development: &development
 test:
   <<: *development
   database: green_flag_dummy_test
+
+production:
+  <<: *development
+


### PR DESCRIPTION
This PR fixes issues with asset compilation.  A few assets were not being precompiled, those are now listed explicitly.  We also now depend on the jquery-rails and uglifier gems.
